### PR TITLE
Fix: Internal "_id" primary key

### DIFF
--- a/library/src/main/java/com/heinrichreimer/inquiry/DatabaseSchemaParser.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/DatabaseSchemaParser.java
@@ -135,6 +135,8 @@ class DatabaseSchemaParser {
         schema.append(getColumnName(field));
         schema.append(" ");
         schema.append(getClassTypeString(converters, field.getType()));
+        if (annotation.primaryKey())
+            schema.append(" PRIMARY KEY");
         if (annotation.unique())
             schema.append(" UNIQUE");
         if (annotation.autoIncrement())
@@ -161,7 +163,6 @@ class DatabaseSchemaParser {
         }
         if (schema.length() == 0)
             throw new IllegalStateException("Class " + type.getName() + " has no column fields.");
-        schema.append(", " + Inquiry.ID + " INTEGER PRIMARY KEY AUTOINCREMENT");
         if (BuildConfig.DEBUG)
             Log.d(Inquiry.DEBUG_TAG, String.format("Schema for %s: %s", type.getSimpleName(), schema.toString()));
         return schema.toString();

--- a/library/src/main/java/com/heinrichreimer/inquiry/annotations/Column.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/annotations/Column.java
@@ -11,6 +11,7 @@ import java.lang.annotation.Target;
 public @interface Column {
     String value() default "";
 
+    boolean primaryKey() default false;
     boolean unique() default false;
     boolean autoIncrement() default false;
     boolean notNull() default false;


### PR DESCRIPTION
### Overview

The library creates `_id` primary key internally and doesn't let the user to create any more primary keys. It is then impossible to select by ID
### Proposed Change

Allow the user to create primary keys.
Don't create the `_id` primary key internal and explain in the README file that needs creating for certain queries to work
