### PR TITLE
Implement upgradable database table

### DIFF
--- a/library/src/main/java/com/heinrichreimer/inquiry/DatabaseHelper.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/DatabaseHelper.java
@@ -5,16 +5,29 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
+import com.heinrichreimer.inquiry.callbacks.UpgradeCallback;
+
 class DatabaseHelper extends SQLiteOpenHelper {
 
     private final String table;
+    private final UpgradeCallback mOnUpgradeCallback;
 
-    public DatabaseHelper(Context context, String databaseName, @NonNull String table, @Nullable String columns, int version) {
+    public DatabaseHelper(
+            Context context,
+            String databaseName,
+            @NonNull String table,
+            @Nullable String columns,
+            @IntRange(from = 1, to = Integer.MAX_VALUE) int version,
+            @Nullable UpgradeCallback upgradeCallback) {
+
         super(context, databaseName, null, version);
+
+        mOnUpgradeCallback = upgradeCallback;
         this.table = table;
         if (columns != null) {
             getWritableDatabase(); //This will invoke onUpgrade if necessary
@@ -29,10 +42,16 @@ class DatabaseHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        if (BuildConfig.DEBUG)
-            Log.w(Inquiry.DEBUG_TAG, "Upgrading database from version " + oldVersion + " to " + newVersion + ", which will destroy all old data");
-        dropTable(db);
-        onCreate(db);
+        if (mOnUpgradeCallback != null) {
+            // OK, somebody will take care of this
+            mOnUpgradeCallback.onUpgrade(db, oldVersion, newVersion);
+        } else {
+            // default behavior when no handler is register is to drop the database
+            if (BuildConfig.DEBUG)
+                Log.w(Inquiry.DEBUG_TAG, "Upgrading database from version " + oldVersion + " to " + newVersion + ", which will destroy all old data");
+            dropTable(db);
+            onCreate(db);
+        }
     }
 
     public final Cursor query(String[] projection, String selection,

--- a/library/src/main/java/com/heinrichreimer/inquiry/DatabaseSchemaParser.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/DatabaseSchemaParser.java
@@ -144,6 +144,29 @@ class DatabaseSchemaParser {
         return schema.toString();
     }
 
+    @Nullable
+    public static List<String> alterDatabase(@NonNull List<Converter> converters, @NonNull Class<?> type, int oldVersion, int newVersion) {
+        ArrayList<String> alterList = new ArrayList<>();
+        List<Field> fields = getAllFields(type);
+        for (Field field : fields) {
+            String fieldSchema = getFieldSchema(converters, field);
+            if (fieldSchema != null) {
+                StringBuilder schema = new StringBuilder();
+                int fieldVersion = field.getAnnotation(Column.class).version();
+                if (fieldVersion > oldVersion && fieldVersion <= newVersion) {
+                    schema.append("ALTER TABLE ").append(getTableName(type)).append(" ADD COLUMN ").append(fieldSchema);
+                    alterList.add(schema.toString());
+                }
+            }
+        }
+
+        if (alterList.size() == 0) {
+            // nothing to alter
+            return null;
+        }
+        return alterList;
+    }
+
     @NonNull
     public static String getClassSchema(@NonNull List<Converter> converters, @NonNull Class<?> type) {
         StringBuilder schema = new StringBuilder();

--- a/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
@@ -26,8 +26,10 @@ public final class Inquiry {
     int databaseVersion = 1;
     private final List<Converter> converters = new LinkedList<>();
 
-    public Inquiry(@NonNull Context context, @Nullable String databaseName,
-            @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
+    public Inquiry(@NonNull Context context,
+                   @Nullable String databaseName,
+                   @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
+
         handler = new Handler();
         this.context = context;
         this.databaseName = databaseName;
@@ -36,7 +38,7 @@ public final class Inquiry {
 
     @NonNull
     public static Inquiry init(@NonNull Context context, @Nullable String databaseName,
-            @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
+                               @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
         inquiry = new Inquiry(context, databaseName, databaseVersion);
         return inquiry;
     }
@@ -83,7 +85,7 @@ public final class Inquiry {
             throw new UnsupportedOperationException("Unable to drop table for type " + type.getSimpleName());
 
         String table = DatabaseSchemaParser.getTableName(type);
-        DatabaseHelper database = new DatabaseHelper(context, databaseName, table, null, databaseVersion);
+        DatabaseHelper database = new DatabaseHelper(context, databaseName, table, null, databaseVersion, /* onUpgrade */ null);
         database.dropTable();
         database.close();
     }

--- a/library/src/main/java/com/heinrichreimer/inquiry/Query.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Query.java
@@ -2,12 +2,15 @@ package com.heinrichreimer.inquiry;
 
 import android.content.ContentValues;
 import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.heinrichreimer.inquiry.callbacks.RunCallback;
+import com.heinrichreimer.inquiry.callbacks.UpgradeCallback;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,7 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
-public final class Query<RowType, RunReturn> {
+public final class Query<RowType, RunReturn> implements UpgradeCallback {
 
     @IntDef({SELECT, INSERT, REPLACE, UPDATE, DELETE})
     @Retention(RetentionPolicy.SOURCE)
@@ -55,7 +58,25 @@ public final class Query<RowType, RunReturn> {
             throw new IllegalStateException("Inquiry was not initialized with a database name, it can only use content providers in this configuration.");
         database = new DatabaseHelper(inquiry.context, inquiry.databaseName,
                 DatabaseSchemaParser.getTableName(rowType),
-                DatabaseSchemaParser.getClassSchema(inquiry.getConverters(), rowType), inquiry.databaseVersion);
+                DatabaseSchemaParser.getClassSchema(inquiry.getConverters(), rowType)
+                , inquiry.databaseVersion, /* onUpgrade */ this);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        List<String> queryList = DatabaseSchemaParser.alterDatabase(inquiry.getConverters(), rowType, oldVersion, newVersion);
+        if (queryList == null) {
+            // onUpgrade without new fields?...re-create to be safe.
+            Log.e(Inquiry.DEBUG_TAG, "onUpgrade: No new COLUMN to be added...O_o...re-creating db");
+            database.dropTable();
+            database.onCreate(db);
+        } else {
+            for (String query : queryList) {
+                if(BuildConfig.DEBUG)
+                    Log.d(Inquiry.DEBUG_TAG, "onUpgrade: " + query);
+                db.execSQL(query);
+            }
+        }
     }
 
     public Query<RowType, RunReturn> atPosition(@IntRange(from = 0, to = Integer.MAX_VALUE) int position) {

--- a/library/src/main/java/com/heinrichreimer/inquiry/annotations/Column.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/annotations/Column.java
@@ -14,4 +14,5 @@ public @interface Column {
     boolean unique() default false;
     boolean autoIncrement() default false;
     boolean notNull() default false;
+    int version() default 1; // database version
 }

--- a/library/src/main/java/com/heinrichreimer/inquiry/callbacks/UpgradeCallback.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/callbacks/UpgradeCallback.java
@@ -1,0 +1,23 @@
+package com.heinrichreimer.inquiry.callbacks;
+
+/*
+ * Copyright (C) 05/09/16 aitorvs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.database.sqlite.SQLiteDatabase;
+
+public interface UpgradeCallback {
+    void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion);
+}


### PR DESCRIPTION
### Proposed Change

Allow the table columns to be annotated also with the (database version) version where they were added.
Upgrade the table when new fields are added instead of drop-and-recreate.
