### PR TITLE
fix: RuntimeException: Can't create handler inside thread that has not called Looper.prepare()

### DIFF
--- a/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
@@ -2,9 +2,11 @@ package com.heinrichreimer.inquiry;
 
 import android.content.Context;
 import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.heinrichreimer.inquiry.convert.Converter;
 
@@ -27,8 +29,16 @@ public final class Inquiry {
     private final List<Converter> converters = new LinkedList<>();
 
     public Inquiry(@NonNull Context context, @Nullable String databaseName,
-            @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
-        handler = new Handler();
+                   @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
+        try {
+            // try to create the handler inside the calling thread. If this thread does not have a
+            // default looper, e.g. JobService(s)...
+            handler = new Handler();
+        } catch (RuntimeException e) {
+            // ... exception will be thrown, so get the main looper
+            Log.w(Inquiry.DEBUG_TAG, "Caller thread has no default looper, using main looper instead");
+            handler = new Handler(Looper.getMainLooper());
+        }
         this.context = context;
         this.databaseName = databaseName;
         this.databaseVersion = databaseVersion;


### PR DESCRIPTION
### Overview

The library creates a `Handler` to land callbacks when using `run(Callback)`, `one(Callback)` or `all(Callback)`. 

``` java
    public Inquiry(@NonNull Context context, @Nullable String databaseName,
                   @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {

        handler = new Handler();
        ...
    }
```

When instantiating the library object from a thread without looper (e.g. JobService) the library with throw a `RuntimeException` and stop working properly.
### Proposed Solution

Falback to main looper when the caller instantiating the library does not have a default looper. This means that using `run(Callback)`, `one(Callback)` or `all(Callback)` in this situation lands the callbacks in the main thread and, this should be clear in the library documentaion.

``` java
    public Inquiry(@NonNull Context context, @Nullable String databaseName,
                   @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {

        try {
            handler = new Handler();
        } catch (RuntimeException e) {
            handler = new Handler(Looper.getMainLooper());
        }
        ...
    }
```
