### PR TITLE
Add precondition checks to library API methods

### DIFF
--- a/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
@@ -14,8 +14,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.heinrichreimer.inquiry.Preconditions.checkNotNull;
-
 public final class Inquiry {
 
     public static final String ID = "_id";
@@ -34,6 +32,8 @@ public final class Inquiry {
                    @Nullable String databaseName,
                    @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
 
+        Preconditions.checkNotNull(context);
+
         try {
             // try to create the handler inside the calling thread. If this thread does not have a
             // default looper, e.g. JobService(s)...
@@ -44,7 +44,7 @@ public final class Inquiry {
             handler = new Handler(Looper.getMainLooper());
         }
 
-        this.context = checkNotNull(context);
+        this.context = context;
         this.databaseName = databaseName;
         this.databaseVersion = databaseVersion;
     }
@@ -52,7 +52,8 @@ public final class Inquiry {
     @NonNull
     public static Inquiry init(@NonNull Context context, @Nullable String databaseName,
                                @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
-        inquiry = new Inquiry(checkNotNull(context), databaseName, databaseVersion);
+        Preconditions.checkNotNull(context);
+        inquiry = new Inquiry(context, databaseName, databaseVersion);
         return inquiry;
     }
 
@@ -94,7 +95,8 @@ public final class Inquiry {
     }
 
     public void dropTable(@NonNull Class<?> type) {
-        if (!DatabaseSchemaParser.isTable(checkNotNull(type)))
+        Preconditions.checkNotNull(type);
+        if (!DatabaseSchemaParser.isTable(type))
             throw new UnsupportedOperationException("Unable to drop table for type " + type.getSimpleName());
 
         String table = DatabaseSchemaParser.getTableName(type);
@@ -105,31 +107,37 @@ public final class Inquiry {
 
     @NonNull
     public <RowType> Query<RowType, Long[]> select(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.SELECT, checkNotNull(rowType));
+        Preconditions.checkNotNull(rowType);
+        return new Query<>(this, Query.SELECT, rowType);
     }
 
     @NonNull
     public <RowType> Query<RowType, Long[]> insert(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.INSERT, checkNotNull(rowType));
+        Preconditions.checkNotNull(rowType);
+        return new Query<>(this, Query.INSERT, rowType);
     }
 
     @NonNull
     public <RowType> Query<RowType, Long[]> insertOrIgnore(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.INSERT_OR_IGNORE, checkNotNull(rowType));
+        Preconditions.checkNotNull(rowType);
+        return new Query<>(this, Query.INSERT_OR_IGNORE, rowType);
     }
 
     @NonNull
     public <RowType> Query<RowType, Long[]> replace(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.REPLACE, checkNotNull(rowType));
+        Preconditions.checkNotNull(rowType);
+        return new Query<>(this, Query.REPLACE, rowType);
     }
 
     @NonNull
     public <RowType> Query<RowType, Integer> update(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.UPDATE, checkNotNull(rowType));
+        Preconditions.checkNotNull(rowType);
+        return new Query<>(this, Query.UPDATE, rowType);
     }
 
     @NonNull
     public <RowType> Query<RowType, Integer> delete(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.DELETE, checkNotNull(rowType));
+        Preconditions.checkNotNull(rowType);
+        return new Query<>(this, Query.DELETE, rowType);
     }
 }

--- a/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Inquiry.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.heinrichreimer.inquiry.Preconditions.checkNotNull;
+
 public final class Inquiry {
 
     public static final String ID = "_id";
@@ -42,7 +44,7 @@ public final class Inquiry {
             handler = new Handler(Looper.getMainLooper());
         }
 
-        this.context = context;
+        this.context = checkNotNull(context);
         this.databaseName = databaseName;
         this.databaseVersion = databaseVersion;
     }
@@ -50,7 +52,7 @@ public final class Inquiry {
     @NonNull
     public static Inquiry init(@NonNull Context context, @Nullable String databaseName,
                                @IntRange(from = 1, to = Integer.MAX_VALUE) int databaseVersion) {
-        inquiry = new Inquiry(context, databaseName, databaseVersion);
+        inquiry = new Inquiry(checkNotNull(context), databaseName, databaseVersion);
         return inquiry;
     }
 
@@ -92,7 +94,7 @@ public final class Inquiry {
     }
 
     public void dropTable(@NonNull Class<?> type) {
-        if (!DatabaseSchemaParser.isTable(type))
+        if (!DatabaseSchemaParser.isTable(checkNotNull(type)))
             throw new UnsupportedOperationException("Unable to drop table for type " + type.getSimpleName());
 
         String table = DatabaseSchemaParser.getTableName(type);
@@ -103,31 +105,31 @@ public final class Inquiry {
 
     @NonNull
     public <RowType> Query<RowType, Long[]> select(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.SELECT, rowType);
+        return new Query<>(this, Query.SELECT, checkNotNull(rowType));
     }
 
     @NonNull
     public <RowType> Query<RowType, Long[]> insert(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.INSERT, rowType);
+        return new Query<>(this, Query.INSERT, checkNotNull(rowType));
     }
 
     @NonNull
     public <RowType> Query<RowType, Long[]> insertOrIgnore(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.INSERT_OR_IGNORE, rowType);
+        return new Query<>(this, Query.INSERT_OR_IGNORE, checkNotNull(rowType));
     }
 
     @NonNull
     public <RowType> Query<RowType, Long[]> replace(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.REPLACE, rowType);
+        return new Query<>(this, Query.REPLACE, checkNotNull(rowType));
     }
 
     @NonNull
     public <RowType> Query<RowType, Integer> update(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.UPDATE, rowType);
+        return new Query<>(this, Query.UPDATE, checkNotNull(rowType));
     }
 
     @NonNull
     public <RowType> Query<RowType, Integer> delete(@NonNull Class<RowType> rowType) {
-        return new Query<>(this, Query.DELETE, rowType);
+        return new Query<>(this, Query.DELETE, checkNotNull(rowType));
     }
 }

--- a/library/src/main/java/com/heinrichreimer/inquiry/Preconditions.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Preconditions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016 Aitor Viana Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.heinrichreimer.inquiry;
+
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
+
+/**
+ * Precondition checks
+ */
+final class Preconditions {
+    public static void checkState(final boolean expression, @NonNull final String errorMessage) {
+        if (!expression) {
+            throw new IllegalStateException(errorMessage);
+        }
+    }
+
+    public static void checkArgument(final boolean expression, @NonNull final String errorMessage) {
+        if (!expression) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @NonNull
+    public static <T> T checkNotNull(@NonNull final T object) {
+        if (object == null) {
+            throw new NullPointerException();
+        }
+        return object;
+    }
+
+    public static @IntRange(from = 0) int checkArgumentNonnegative(final int value,
+                                                                   final String errorMessage) {
+        if (value < 0) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        return value;
+    }
+
+    private Preconditions() {}
+}

--- a/library/src/main/java/com/heinrichreimer/inquiry/Query.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Query.java
@@ -20,8 +20,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
-import static com.heinrichreimer.inquiry.Preconditions.checkNotNull;
-
 public final class Query<RowType, RunReturn> implements UpgradeCallback {
 
     @IntDef({SELECT, INSERT, REPLACE, UPDATE, DELETE, INSERT_OR_IGNORE})
@@ -113,7 +111,9 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
     }
 
     public Query<RowType, RunReturn> where(@NonNull String selection, @Nullable Object... selectionArgs) {
-        int args = Utils.countOccurrences(checkNotNull(selection), '?');
+        Preconditions.checkNotNull(selection);
+
+        int args = Utils.countOccurrences(selection, '?');
         if ((selectionArgs == null && args != 0) ||
                 (selectionArgs != null && selectionArgs.length != args))
             throw new IllegalArgumentException("There must be exactly as many selection args as " +
@@ -126,11 +126,13 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
     }
 
     public Query<RowType, RunReturn> whereIn(@NonNull String column, @Nullable Object... selectionArgs) {
+        Preconditions.checkNotNull(column);
+
         if (selectionArgs == null)
             return this;
 
         StringBuilder in = new StringBuilder();
-        in.append(checkNotNull(column));
+        in.append(column);
         in.append(" IN (");
         boolean first = true;
         for (Object ignored : selectionArgs) {
@@ -184,8 +186,9 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
 
     @SuppressWarnings("unchecked")
     public final Query<RowType, RunReturn> value(@NonNull Object value) {
+        Preconditions.checkNotNull(value);
         values = (RowType[]) Array.newInstance(rowType, 1);
-        Array.set(values, 0, checkNotNull(value));
+        Array.set(values, 0, value);
         return this;
     }
 
@@ -212,6 +215,8 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
     }
 
     public void one(@NonNull final RunCallback<RowType> callback) {
+        Preconditions.checkNotNull(callback);
+
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -220,7 +225,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
                 inquiry.handler.post(new Runnable() {
                     @Override
                     public void run() {
-                        checkNotNull(callback).result(results);
+                        callback.result(results);
                     }
                 });
             }
@@ -233,6 +238,8 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
     }
 
     public void all(@NonNull final RunCallback<RowType[]> callback) {
+        Preconditions.checkNotNull(callback);
+
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -241,7 +248,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
                 inquiry.handler.post(new Runnable() {
                     @Override
                     public void run() {
-                        checkNotNull(callback).result(results);
+                        callback.result(results);
                     }
                 });
             }
@@ -314,6 +321,8 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
     }
 
     public void run(@NonNull final RunCallback<RunReturn> callback) {
+        Preconditions.checkNotNull(callback);
+
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -322,7 +331,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
                 inquiry.handler.post(new Runnable() {
                     @Override
                     public void run() {
-                        checkNotNull(callback).result(changed);
+                        callback.result(changed);
                     }
                 });
             }

--- a/library/src/main/java/com/heinrichreimer/inquiry/Query.java
+++ b/library/src/main/java/com/heinrichreimer/inquiry/Query.java
@@ -20,6 +20,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
+import static com.heinrichreimer.inquiry.Preconditions.checkNotNull;
+
 public final class Query<RowType, RunReturn> implements UpgradeCallback {
 
     @IntDef({SELECT, INSERT, REPLACE, UPDATE, DELETE, INSERT_OR_IGNORE})
@@ -111,7 +113,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
     }
 
     public Query<RowType, RunReturn> where(@NonNull String selection, @Nullable Object... selectionArgs) {
-        int args = Utils.countOccurrences(selection, '?');
+        int args = Utils.countOccurrences(checkNotNull(selection), '?');
         if ((selectionArgs == null && args != 0) ||
                 (selectionArgs != null && selectionArgs.length != args))
             throw new IllegalArgumentException("There must be exactly as many selection args as " +
@@ -128,7 +130,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
             return this;
 
         StringBuilder in = new StringBuilder();
-        in.append(column);
+        in.append(checkNotNull(column));
         in.append(" IN (");
         boolean first = true;
         for (Object ignored : selectionArgs) {
@@ -183,7 +185,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
     @SuppressWarnings("unchecked")
     public final Query<RowType, RunReturn> value(@NonNull Object value) {
         values = (RowType[]) Array.newInstance(rowType, 1);
-        Array.set(values, 0, value);
+        Array.set(values, 0, checkNotNull(value));
         return this;
     }
 
@@ -218,7 +220,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
                 inquiry.handler.post(new Runnable() {
                     @Override
                     public void run() {
-                        callback.result(results);
+                        checkNotNull(callback).result(results);
                     }
                 });
             }
@@ -239,7 +241,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
                 inquiry.handler.post(new Runnable() {
                     @Override
                     public void run() {
-                        callback.result(results);
+                        checkNotNull(callback).result(results);
                     }
                 });
             }
@@ -320,7 +322,7 @@ public final class Query<RowType, RunReturn> implements UpgradeCallback {
                 inquiry.handler.post(new Runnable() {
                     @Override
                     public void run() {
-                        callback.result(changed);
+                        checkNotNull(callback).result(changed);
                     }
                 });
             }


### PR DESCRIPTION
#### Proposed change

Add precondition checks to API library methods, e.g. `checkNotNull`

Example usage:

``` java
    @NonNull
    public <RowType> Query<RowType, Long[]> insert(@NonNull Class<RowType> rowType) {
        return new Query<>(this, Query.INSERT, checkNotNull(rowType));
    }
```
